### PR TITLE
fix: correct trans tag syntax in password reset template

### DIFF
--- a/templates/registration/password_reset_confirm.html
+++ b/templates/registration/password_reset_confirm.html
@@ -1,6 +1,6 @@
 {% extends 'registration/registration_base.html' %}
 {% load i18n %}
-{% block title %}{% trans 'New Password | Learning management system %}{% endblock title %}
+{% block title %}{% trans 'New Password | Learning management system' %}{% endblock title %}
 {% load crispy_forms_tags %}
 {% block content %}
 


### PR DESCRIPTION
## Description

This pull request fixes a template rendering error in `password_reset_confirm.html` caused by incorrect usage of quotes in the `{% trans %}` tag.

### Changes Made

- Fixed invalid quote syntax in `{% trans '...' %}` on line 3 of the template
- Ensured the title block renders correctly without template errors

### Notes

This issue was causing a `Could not parse the remainder` error when loading the password reset page. The fix allows the template to compile and display as expected.

## Checklist

- [x] Verified fix locally
- [x] Minimal and focused change
- [x] No breaking changes introduced
